### PR TITLE
1.12.19-RELEASE

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,7 +11,17 @@ All notable changes to this project will be documented in this file. The types o
 
 ---
 
+## __1.12.19__ ([2022-06-17](https://github.com/MarioCatuogno/Clean-macOS/milestone/8))
+
+Update docs.
+
+__DOCS__
+
+* 📝 update CHANGELOG file
+
 ## __1.12.18__ ([2022-06-17](https://github.com/MarioCatuogno/Clean-macOS/milestone/8))
+
+Fix some brew commands.
 
 __CHANGED__
 


### PR DESCRIPTION
## __1.12.19__ ([2022-06-17](https://github.com/MarioCatuogno/Clean-macOS/milestone/8))

Update docs.

__DOCS__

* 📝 update CHANGELOG file