### PR TITLE
1.13.0-RELEASE

### DIFF
--- a/Clean-macOS.sh
+++ b/Clean-macOS.sh
@@ -1,42 +1,58 @@
 #!/bin/bash
 
+set -e
+
 ###############################################################################
 # Set variables                                                               #
 ###############################################################################
 
-BIN=~/Clean-macOS/bin                # shell scripts
-CONFIG=~/Clean-macOS/config          # configuration files directory
-SETUP=~/Clean-macOS                  # root folder of Clean-macOS
+BIN="${HOME}/Clean-macOS/bin"                # shell scripts
+CONFIG="${HOME}/Clean-macOS/config"          # configuration files directory
+SETUP="${HOME}/Clean-macOS"                  # root folder of Clean-macOS
 
 ###############################################################################
 # Menu                                                                        #
 ###############################################################################
 
-while :
-do
-    clear
-    cat<<EOF
-    ########################################################################
-    # Clean-macOS                                                          #
-    # Version : 1.12.21                                                    #
-    ########################################################################
-    #                                                                      #
-    #  Please enter your choice:                                           #
-    #                                                                      #
-    #  (1) Install                                                         #
-    #  (2) Configure                                                       #
-    #  (3) Update                                                          #
-    #  (0) Exit                                                            #
-    #                                                                      #
-    ########################################################################
+install() {
+  echo "Ready to install Homebrew..."
+  "${BIN}/install.sh"
+}
+
+configure() {
+  echo "Ready to configure macOS..."
+  "${BIN}/config.sh"
+}
+
+update() {
+  echo "Ready to update Homebrew..."
+  "${BIN}/update.sh"
+}
+
+while true; do
+  clear
+  cat <<EOF
+  ########################################################################
+  # Clean-macOS                                                          #
+  # Version : 1.13.0                                                     #
+  ########################################################################
+  #                                                                      #
+  #  Please enter your choice:                                           #
+  #                                                                      #
+  #  (1) Install                                                         #
+  #  (2) Configure                                                       #
+  #  (3) Update                                                          #
+  #  (0) Exit                                                            #
+  #                                                                      #
+  ########################################################################
 EOF
-    read -n1 -s
-    case "$REPLY" in
-    "1")  echo "Ready to install Homebrew..."            | $BIN/install.sh       ;;
-    "2")  echo "Ready to configure macOS..."             | $BIN/config.sh        ;;
-    "3")  echo "Ready to update Homebrew..."             | $BIN/update.sh        ;;
-    "0")  exit                                                                   ;;
-     * )  echo "Invalid option!"                                                 ;;
-    esac
-    sleep 1
+  read -n1 -s
+  case "$REPLY" in
+    1) install ;;
+    2) configure ;;
+    3) update ;;
+    0) exit ;;
+    *) echo "Invalid option!" ;;
+  esac
+  sleep 1
 done

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -4,51 +4,63 @@
 # Set variables                                                               #
 ###############################################################################
 
-BIN=~/Clean-macOS/bin                # shell scripts
-CONFIG=~/Clean-macOS/config          # configuration files directory
-SETUP=~/Clean-macOS                  # root folder of Clean-macOS
-SUDO_USER=$(whoami)                  # sudo user variable
+# Set variables
+CONFIG="${HOME}/Clean-macOS/config"             # configuration files directory
+PROJECTS_DIR=${HOME}/Projects                   # projects directory
+ZSH_CUSTOM=${ZSH_CUSTOM:-~/.oh-my-zsh/custom}   # ZSH directory
 
 ###############################################################################
 # Configure                                                                   #
 ###############################################################################
 
-# Entering as Root
-printf "Enter root password...\n"
+# Exit script immediately if any command fails
+set -e
+
+# Prompt for root password
+echo "Enter root password..."
 sudo -v
 
-# Keep alive Root
-while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+# Keep root session alive
+while true; do
+  sudo -n true
+  sleep 60
+  kill -0 "$$" || exit
+done 2>/dev/null &
 
-# Install Oh-My-Zsh [1/4]
-printf "📦 Install Oh-My-Zsh...\n"
+# Install Oh-My-Zsh
+echo "📦 Install Oh-My-Zsh..."
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
-# Install Zsh plugins [2/4]
-printf "📦 Install Zsh plugins...\n"
-git clone https://github.com/zsh-users/zsh-completions ${ZSH_CUSTOM:=~/.oh-my-zsh/custom}/plugins/zsh-completions
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+# Install Zsh plugins
+echo "📦 Install Zsh plugins..."
+git clone https://github.com/zsh-users/zsh-completions $ZSH_CUSTOM/plugins/zsh-completions
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $ZSH_CUSTOM/plugins/zsh-syntax-highlighting
+git clone https://github.com/zsh-users/zsh-autosuggestions $ZSH_CUSTOM/plugins/zsh-autosuggestions
 
-# Update Zsh settings [3/4]
-printf "⚙️ Update Zsh settings...\n"
+# Update Zsh settings
+echo "⚙️ Update Zsh settings..."
 sudo rm -rf ~/.zshrc > /dev/null 2>&1
-cp $CONFIG/.zshrc ~/.zshrc
+cp "$CONFIG/.zshrc" ~/.zshrc
 
-# Install iTerm2 themes [4/4]
-printf "📦 Install iTerm2 themes...\n"
-open $CONFIG/ayu-dark.itermcolors
-open $CONFIG/ayu-light.itermcolors
-open $CONFIG/ayu-mirage.itermcolors
-open $CONFIG/nord.itermcolors
-open $CONFIG/nord.terminal
+# Install iTerm2 themes
+echo "📦 Install iTerm2 themes..."
+open "$CONFIG/ayu-dark.itermcolors"
+open "$CONFIG/ayu-light.itermcolors"
+open "$CONFIG/ayu-mirage.itermcolors"
+open "$CONFIG/nord.itermcolors"
+open "$CONFIG/nord.terminal"
 
-# Update Git settings [1/1]
-printf "⚙️ Update Git settings...\n"
+# Update Git settings
+echo "⚙️ Update Git settings..."
 sudo rm -rf ~/.gitconfig > /dev/null 2>&1
 sudo rm -rf ~/.gitignore > /dev/null 2>&1
-cp $CONFIG/.gitignore ~/.gitignore
-cp $CONFIG/.gitconfig ~/.gitconfig
+cp "$CONFIG/.gitignore" ~/.gitignore
+cp "$CONFIG/.gitconfig" ~/.gitconfig
+
+# Create Projects directory
+echo "⚙️ Create Projects directory..."
+mkdir "$PROJECTS_DIR"
+chmod 777 "$PROJECTS_DIR"
 
 # Configure macOS Desktop
 printf "⚙️ Configure Desktop...\n"
@@ -69,7 +81,7 @@ chflags nohidden ~/Library
 # Configure macOS Screen Capture
 printf "⚙️ Save screenshots in PNG format...\n"
 mkdir ~/Pictures/Screenshots
-defaults write com.apple.screencapture location -string "~/Pictures/Screenshots"
+defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
 defaults write com.apple.screencapture type -string "png"
 
 # Configure macOS Keyboard
@@ -117,18 +129,13 @@ sudo pmset -a hibernatemode 0
 
 # Change name if you do not own a MacBook
 printf "⚙️ Configure computer name...\n"
-sudo scutil --set ComputerName "MacBook"
-sudo scutil --set HostName "MacBook"
-sudo scutil --set LocalHostName "MacBook"
-sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server NetBIOSName -string "MacBook"
+sudo scutil --set ComputerName "MecBuk"
+sudo scutil --set HostName "MecBuk"
+sudo scutil --set LocalHostName "MecBuk"
+sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server NetBIOSName -string "MecBuk"
 
-# Create Projects directory
-printf "⚙️ Create Projects directory...\n"
-mkdir ${HOME}/Projects
-chmod 777 ${HOME}/Projects
-
-# Cleanup
-printf "⚙️ Cleanup and final touches...\n"
+# Cleanup and final touches
+echo "⚙️ Cleanup and final touches..."
 brew -v update && brew -v upgrade && mas upgrade && brew -v cleanup --prune=2 && brew doctor && brew -v upgrade --casks --greedy
 
 # Exit script

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -4,14 +4,21 @@
 # Set variables                                                               #
 ###############################################################################
 
-BIN=~/Clean-macOS/bin                # shell scripts
-CONFIG=~/Clean-macOS/config          # configuration files directory
-SETUP=~/Clean-macOS                  # root folder of Clean-macOS
+BIN="${HOME}/Clean-macOS/bin"                # shell scripts
+CONFIG="${HOME}/Clean-macOS/config"          # configuration files directory
+SETUP="${HOME}/Clean-macOS"                  # root folder of Clean-macOS
 SUDO_USER=$(whoami)                  # sudo user variable
 
 ###############################################################################
 # Update                                                                      #
 ###############################################################################
+
+# Check if Homebrew is installed
+if ! command -v brew &> /dev/null
+then
+    echo "Homebrew is not installed. Aborting."
+    exit 1
+fi
 
 # Entering as Root
 printf "Enter root password...\n"
@@ -20,9 +27,26 @@ sudo -v
 # Keep alive Root
 while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 
-# Cleanup
-printf "⚙️ Cleanup and final touches...\n"
-brew -v update && brew -v upgrade && mas upgrade && brew -v cleanup --prune=2 && brew doctor && brew -v upgrade --casks --greedy 
+# Update Homebrew
+printf "⚙️ Updating Homebrew...\n"
+brew update-reset
 
-#Exit script
+# Update Mac App Store applications
+printf "⚙️ Updating Mac App Store applications...\n"
+outdated_apps=$(mas outdated)
+if [ ! -z "$outdated_apps" ]
+then
+    while IFS= read -r app; do
+        app_id=$(echo "$app" | awk '{ print $1 }')
+        app_name=$(echo "$app" | awk '{$1=""; print $0}')
+        printf "Updating %s...\n" "$app_name"
+        mas upgrade "$app_id"
+    done <<< "$outdated_apps"
+fi
+
+# Cleanup
+printf "⚙️ Cleaning up Homebrew...\n"
+brew cleanup -s && brew doctor && brew upgrade --cask --greedy
+
+# Exit script
 exit

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,22 @@ All notable changes to this project will be documented in this file. The types o
 
 ---
 
+## __1-13.0__ ([2023-02-28](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))
+
+Major release.
+
+__DOCS__
+
+* 📝 update CHANGELOG file
+
+__CHANGED__
+
+* 🔥 add error handling for the commands in the case statements to handle cases where the command fails or returns an error
+* 🔥 use a more descriptive name for the script file
+* 🔥 use absolute path instead of relative paths for variables in `Clean-macOS.sh` script
+* 🔥 use functions to encapsulate the functionality of each case statement, instead of using the pipeline to pass data
+* 🔥 use shellcheck to check for any potential issues in the script
+
 ## __1.12.22__ ([2022-12-14](https://github.com/MarioCatuogno/Clean-macOS/milestone/8))
 
 Minor release with some changes in Brewfile.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,11 +21,19 @@ __DOCS__
 
 __CHANGED__
 
-* 🔥 add error handling for the commands in the case statements to handle cases where the command fails or returns an error
-* 🔥 use a more descriptive name for the script file
-* 🔥 use absolute path instead of relative paths for variables in `Clean-macOS.sh` script
-* 🔥 use functions to encapsulate the functionality of each case statement, instead of using the pipeline to pass data
-* 🔥 use shellcheck to check for any potential issues in the script
+* 🔥 add a check to see if Homebrew is already installed before running the `update.sh` script
+* 🔥 add error handling for the commands in the case statements to handle cases where the command fails or returns an error in shell scripts
+* 🔥 use a more descriptive name for the script file in shell scripts
+* 🔥 use absolute path instead of relative paths for variables in shell scripts
+* 🔥 use double quotes around variable references to prevent word splitting and globbing in `install.sh` script
+* 🔥 use functions to encapsulate the functionality of each case statement, instead of using the pipeline to pass data in shell scripts
+* 🔥 use shellcheck to check for any potential issues in the script in shell scripts
+* 🔥 use the `brew update-reset` command instead of `brew update` to ensure that the Homebrew installation is fully up-to-date
+* 🔥 use the `mas outdated` command instead of `mas upgrade` to list outdated applications and then use mas upgrade <app-id> to upgrade individual applications
+
+__REMOVED__
+
+* 🗑️ remove unnecessary variables such as `SETUP` and `SUDO_USER` in `config.sh` script
 
 ## __1.12.22__ ([2022-12-14](https://github.com/MarioCatuogno/Clean-macOS/milestone/8))
 


### PR DESCRIPTION
## __1-13.0__ ([2023-02-28](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))

Major release.

__DOCS__

* 📝 update CHANGELOG file

__CHANGED__

* 🔥 add a check to see if Homebrew is already installed before running the `update.sh` script
* 🔥 add error handling for the commands in the case statements to handle cases where the command fails or returns an error in shell scripts
* 🔥 use a more descriptive name for the script file in shell scripts
* 🔥 use absolute path instead of relative paths for variables in shell scripts
* 🔥 use double quotes around variable references to prevent word splitting and globbing in `install.sh` script
* 🔥 use functions to encapsulate the functionality of each case statement, instead of using the pipeline to pass data in shell scripts
* 🔥 use shellcheck to check for any potential issues in the script in shell scripts
* 🔥 use the `brew update-reset` command instead of `brew update` to ensure that the Homebrew installation is fully up-to-date
* 🔥 use the `mas outdated` command instead of `mas upgrade` to list outdated applications and then use mas upgrade <app-id> to upgrade individual applications

__REMOVED__

* 🗑️ remove unnecessary variables such as `SETUP` and `SUDO_USER` in `config.sh` script