### PR TITLE
1.13.3-RELEASE

### DIFF
--- a/bin/config.sh
+++ b/bin/config.sh
@@ -39,8 +39,8 @@ git clone https://github.com/zsh-users/zsh-autosuggestions $ZSH_CUSTOM/plugins/z
 
 # Update Zsh settings
 echo "⚙️ Update Zsh settings..."
-sudo rm -rf ~/.zshrc > /dev/null 2>&1
-cp "$CONFIG/.zshrc" ~/.zshrc
+sudo rm -rf ${HOME}/.zshrc > /dev/null 2>&1
+cp "$CONFIG/.zshrc" ${HOME}/.zshrc
 
 # Install iTerm2 themes
 echo "📦 Install iTerm2 themes..."
@@ -52,10 +52,10 @@ open "$CONFIG/nord.terminal"
 
 # Update Git settings
 echo "⚙️ Update Git settings..."
-sudo rm -rf ~/.gitconfig > /dev/null 2>&1
-sudo rm -rf ~/.gitignore > /dev/null 2>&1
-cp "$CONFIG/.gitignore" ~/.gitignore
-cp "$CONFIG/.gitconfig" ~/.gitconfig
+sudo rm -rf ${HOME}/.gitconfig > /dev/null 2>&1
+sudo rm -rf ${HOME}/.gitignore > /dev/null 2>&1
+cp "$CONFIG/.gitignore" ${HOME}/.gitignore
+cp "$CONFIG/.gitconfig" ${HOME}/.gitconfig
 
 # Create Projects directory
 echo "⚙️ Create Projects directory..."

--- a/config/.gitconfig
+++ b/config/.gitconfig
@@ -5,6 +5,6 @@
     clean = git-lfs clean -- %f
 [user]
     name = Mario Catuogno
-    email = mario.catuogno@gmail.com
+    email = lister.dollar-0c@icloud.com
 [core]
     excludesfile = ~/.gitignore

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,16 @@ All notable changes to this project will be documented in this file. The types o
 
 ---
 
+## __1-13.3__ ([2023-03-08](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))
+
+__DOCS__
+
+* 📝 update CHANGELOG file
+
+__CHANGED__
+
+* 🔥 change the email address in `.gitconfig` file
+
 ## __1-13.2__ ([2023-03-07](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))
 
 This minor release includes improved documentation and an updated Brewfile, which contains a list of applications that can be installed on macOS using the Homebrew package manager.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file. The types o
 
 ## __1-13.3__ ([2023-03-08](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))
 
+This minor release fix a variable and change email address to an alias.
+
 __DOCS__
 
 * 📝 update CHANGELOG file
@@ -20,6 +22,10 @@ __DOCS__
 __CHANGED__
 
 * 🔥 change the email address in `.gitconfig` file
+
+__FIXED__
+
+* 🐛 fix variable in `config.sh` script
 
 ## __1-13.2__ ([2023-03-07](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))
 


### PR DESCRIPTION
## __1-13.3__ ([2023-03-08](https://github.com/MarioCatuogno/Clean-macOS/milestone/9))

This minor release fix a variable and change email address to an alias.

__DOCS__

* 📝 update CHANGELOG file

__CHANGED__

* 🔥 change the email address in `.gitconfig` file

__FIXED__

* 🐛 fix variable in `config.sh` script